### PR TITLE
fix(batch): fix memory leak that occurs when using batch

### DIFF
--- a/index.js
+++ b/index.js
@@ -228,8 +228,9 @@ class RocksLevel extends AbstractLevel {
         assert(false)
       }
     }
-    batch._write(options, callback)
-
+    batch._write(options, () => {
+      batch._close(callback);
+    })
     return callback[kPromise]
   }
 

--- a/index.js
+++ b/index.js
@@ -229,7 +229,7 @@ class RocksLevel extends AbstractLevel {
       }
     }
     batch._write(options, () => {
-      batch._close(callback);
+      batch.close(callback);
     })
     return callback[kPromise]
   }


### PR DESCRIPTION
Hi @ronag,
I found a memory leak when using batch, and I fixed it. 
* Add missing call to `batch.close()`

The RocksLevel.batch function didn’t free memory because the batch wasn’t closed.
Thanks!