### PR TITLE
Fix: Build after c++23 update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,6 +59,7 @@ RUN cd /opt && git clone https://github.com/jemalloc/jemalloc.git && cd jemalloc
 
 RUN cd /opt && git clone --depth 1 --branch 1.2.1 https://github.com/google/snappy.git && cd snappy && \
   git submodule update --init && \
+  sed -i 's/-fno-rtti//g' CMakeLists.txt && \
   cmake . -DCMAKE_BUILD_TYPE=Release -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
     -DCMAKE_CXX_FLAGS="-march=znver3 -mtune=znver3 -O3" \
     -DSNAPPY_BUILD_TESTS=OFF \

--- a/binding.cc
+++ b/binding.cc
@@ -948,6 +948,11 @@ napi_status InitOptions(napi_env env, T& columnOptions, const U& options) {
     columnOptions.compression_opts.max_dict_bytes = 16 * 1024;
     columnOptions.compression_opts.zstd_max_train_bytes = 16 * 1024 * 100;
     // TODO (perf): compression_opts.parallel_threads
+  } else {
+    columnOptions.compression = rocksdb::kNoCompression;
+    for (auto& c : columnOptions.compression_per_level) {
+      c = rocksdb::kNoCompression;
+    }
   }
 
   std::string prefixExtractor;

--- a/binding.gyp
+++ b/binding.gyp
@@ -20,8 +20,8 @@
                           "/usr/local/lib/libre2.a",
                           "<!@(ls /usr/local/lib/libabsl_*.a)"
                         ],
-                        "cflags": ["-march=znver3", "-mtune=znver3"],
-                        "cflags_cc": ["-flto", "-std=c++23", "-march=znver3", "-mtune=znver3"],
+                        "cflags": [],
+                        "cflags_cc": ["-flto", "-std=c++23"],
                         "cflags!": ["-fno-exceptions"],
                         "cflags_cc!": ["-fno-exceptions"],
                         "ldflags": ["-flto", "-fuse-linker-plugin", "-Wl,--whole-archive,/usr/local/lib/libsnappy.a,--no-whole-archive"],

--- a/binding.gyp
+++ b/binding.gyp
@@ -17,13 +17,14 @@
                           "/usr/lib/include",
                         ],
                         "libraries": [
-                          "/usr/local/lib/libre2.a"
+                          "/usr/local/lib/libre2.a",
+                          "<!@(ls /usr/local/lib/libabsl_*.a)"
                         ],
                         "cflags": ["-march=znver3", "-mtune=znver3"],
-                        "ccflags": ["-flto", '-std=c++23', "-march=znver3", "-mtune=znver3"],
+                        "cflags_cc": ["-flto", "-std=c++23", "-march=znver3", "-mtune=znver3"],
                         "cflags!": ["-fno-exceptions"],
                         "cflags_cc!": ["-fno-exceptions"],
-                        "ldflags": ["-flto", "-fuse-linker-plugin"],
+                        "ldflags": ["-flto", "-fuse-linker-plugin", "-Wl,--whole-archive,/usr/local/lib/libsnappy.a,--no-whole-archive"],
                     },
                 ],
                 [

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -e
 
+echo "Initializing submodules..."
+git submodule update --init
+
 echo "Building image..."
 docker build --iidfile prebuilds.iid .
 

--- a/deps/rocksdb/rocksdb.gyp
+++ b/deps/rocksdb/rocksdb.gyp
@@ -9,6 +9,7 @@
         "include_dirs": ["rocksdb/include/"]
       },
       "defines": [
+        "SNAPPY=1",
         "ZSTD=1",
         "ZSTD_STATIC_LINKING_ONLY=1",
         "ROCKSDB_BACKTRACE=1",
@@ -107,7 +108,8 @@
                 "/usr/lib/x86_64-linux-gnu/libglog.a",
                 "/usr/lib/x86_64-linux-gnu/libiberty.a",
                 "/usr/lib/x86_64-linux-gnu/libunwind.a",
-                "/usr/lib/x86_64-linux-gnu/libgflags.a"
+                "/usr/lib/x86_64-linux-gnu/libgflags.a",
+                "/usr/local/lib/libsnappy.a"
                 # "/usr/lib/x86_64-linux-gnu/libjemalloc.a"
               ],
             },


### PR DESCRIPTION
Removed some Epic specific code as GCC's LTO pass was generating broken code for the Worker struct layout when -march=znver3 was combined with -flto across the C++23 binding code, this only affects N-API.

The RocksDb code still compiles with EPYC optimisation.

3 Commits are made:
1: Linux build fail (ccflags should be cflags_cc)
2: Test data compression error.
3: Segfault - GCC's LTO pass was generating broken code